### PR TITLE
fix: Improves avoiding duplicate posts titles

### DIFF
--- a/src/models/plugins/reddit.model.ts
+++ b/src/models/plugins/reddit.model.ts
@@ -9,6 +9,7 @@ export const RedditModel = {
   name: 'javascript',
   description: 'The programming language of the web',
   latestPostId: '',
+  lastPostTitle: '',
   subscribedGuilds: [
     {
       id: '',

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,1 @@
+export const RedditTitleGroup = /\[(.*?)\]/g


### PR DESCRIPTION
## 🧬 Details

> Explain the details for making this change. What existing problem does the pull request solve?

Adds a new 'sanity check' for post titles, I know it's not perfect (since it only compares with the latest stored title) but now if a subreddit gets spammed with the same post title, the new function will try to compare them, if it matches at >= 50%, it won't repost it.


Note: For a future improvement, we could store a temporally (x amount of days so if titles match but it's actually new content, skip the verification)  all the titles that were sent and compare it with those.