### PR TITLE
fix: regex to allow timezones with format Continent/Country_Name

### DIFF
--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,3 +1,3 @@
 export const ROLE_MENTION_REGEX = /@(\w+)/g
 export const MESSAGE_ID_REGEX = /^(\d{19})$/
-export const TIME_ZONES_REGEX = new RegExp('^([A-Za-z]+/[A-Za-z]+)$')
+export const TIME_ZONES_REGEX = new RegExp('^([A-Za-z]+/[A-Za-z_]+)$')


### PR DESCRIPTION
fix: regex to allow timezones with format `Continent/Country_Name`